### PR TITLE
feat: add message archive system with SQLite

### DIFF
--- a/src/Models/ArchiveDbContext.cs
+++ b/src/Models/ArchiveDbContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Models;
+
+public class ArchiveDbContext : DbContext
+{
+    public DbSet<MessageRecord> Messages => Set<MessageRecord>();
+
+    public ArchiveDbContext() { }
+
+    public ArchiveDbContext(DbContextOptions<ArchiveDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MessageRecord>(entity =>
+        {
+            entity.ToTable("Messages");
+
+            entity.HasIndex(e => e.AuthorId);
+            entity.HasIndex(e => e.ChannelId);
+            entity.HasIndex(e => e.GuildId);
+            entity.HasIndex(e => e.MessageId).IsUnique();
+        });
+    }
+}

--- a/src/Models/MessageRecord.cs
+++ b/src/Models/MessageRecord.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace App.Models;
+
+public class MessageRecord
+{
+    [Key]
+    public int Id { get; set; }
+
+    public ulong MessageId { get; set; }
+    public ulong ChannelId { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong AuthorId { get; set; }
+
+    public string AuthorName { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; }
+    public string? Attachments { get; set; }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -77,6 +77,8 @@ internal static class Program {
 
         await host.Services.GetRequiredService<InteractionHandler>().InitializeAsync();
 
+        host.Services.GetRequiredService<MessageArchiveService>().Start();
+
         await host.RunAsync();
     }
 

--- a/src/Services/MessageArchiveService.cs
+++ b/src/Services/MessageArchiveService.cs
@@ -2,7 +2,6 @@ using App.Attributes;
 using App.Models;
 using Discord;
 using Discord.WebSocket;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace App.Services;
@@ -15,8 +14,8 @@ public class MessageArchiveService
     readonly DiscordSocketClient _discord;
     readonly LoggingService _log;
     readonly SemaphoreSlim _dbLock = new(1, 1);
-    bool _backfillStarted;
-    bool _backfillComplete;
+    volatile bool _backfillStarted;
+    volatile bool _backfillComplete;
 
     public MessageArchiveService(DiscordSocketClient discord, LoggingService log)
     {
@@ -45,13 +44,18 @@ public class MessageArchiveService
     {
         _discord.MessageReceived += OnMessageReceived;
         if (!_backfillComplete)
-            _discord.Ready += OnReady;
+        {
+            if (_discord.ConnectionState == ConnectionState.Connected)
+                _ = Task.Run(BackfillAllChannelsAsync);
+            else
+                _discord.Ready += OnReady;
+        }
     }
 
     async Task OnReady()
     {
         _discord.Ready -= OnReady;
-        await BackfillAllChannelsAsync();
+        await Task.Run(BackfillAllChannelsAsync);
     }
 
     async Task OnMessageReceived(SocketMessage socketMessage)
@@ -206,11 +210,9 @@ public class MessageArchiveService
 
     ArchiveDbContext CreateContext()
     {
-        var connection = new SqliteConnection($"Data Source={DB_PATH}");
-        connection.Open();
         return new ArchiveDbContext(
             new DbContextOptionsBuilder<ArchiveDbContext>()
-                .UseSqlite(connection)
+                .UseSqlite($"Data Source={DB_PATH}")
                 .Options
         );
     }

--- a/src/Services/MessageArchiveService.cs
+++ b/src/Services/MessageArchiveService.cs
@@ -1,0 +1,207 @@
+using App.Attributes;
+using App.Models;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Services;
+
+[Service]
+public class MessageArchiveService
+{
+    const string DB_PATH = "../JsonData/Archive/messages.db";
+
+    readonly DiscordSocketClient _discord;
+    readonly LoggingService _log;
+    readonly SemaphoreSlim _dbLock = new(1, 1);
+    bool _backfillStarted;
+    bool _backfillComplete;
+
+    public MessageArchiveService(DiscordSocketClient discord, LoggingService log)
+    {
+        _discord = discord;
+        _log = log;
+
+        EnsureDatabase();
+    }
+
+    void EnsureDatabase()
+    {
+        var dir = Path.GetDirectoryName(DB_PATH);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        using var ctx = CreateContext();
+        ctx.Database.EnsureCreated();
+
+        var hasMessages = ctx.Messages.Any();
+        _backfillComplete = hasMessages;
+
+        _log.Info($"Archive database ready at {DB_PATH} (has data: {hasMessages})");
+    }
+
+    public void Start()
+    {
+        _discord.MessageReceived += OnMessageReceived;
+
+        if (!_backfillComplete)
+        {
+            _ = BackfillAllChannelsAsync();
+        }
+    }
+
+    async Task OnMessageReceived(SocketMessage socketMessage)
+    {
+        if (socketMessage is not SocketUserMessage userMessage) return;
+        if (userMessage.Author.IsBot) return;
+        if (string.IsNullOrEmpty(userMessage.Content)) return;
+
+        try
+        {
+            using var ctx = CreateContext();
+
+            if (await ctx.Messages.AnyAsync(m => m.MessageId == userMessage.Id))
+                return;
+
+            var record = new MessageRecord
+            {
+                MessageId = userMessage.Id,
+                ChannelId = userMessage.Channel.Id,
+                GuildId = (userMessage.Channel as IGuildChannel)?.GuildId ?? 0,
+                AuthorId = userMessage.Author.Id,
+                AuthorName = userMessage.Author.Username,
+                Content = userMessage.Content,
+                Timestamp = userMessage.Timestamp.UtcDateTime,
+                Attachments = userMessage.Attachments.Count > 0
+                    ? string.Join(";", userMessage.Attachments.Select(a => a.Url))
+                    : null
+            };
+
+            await _dbLock.WaitAsync();
+            try
+            {
+                ctx.Messages.Add(record);
+                await ctx.SaveChangesAsync();
+            }
+            finally
+            {
+                _dbLock.Release();
+            }
+        }
+        catch (Exception e)
+        {
+            _log.Error($"Failed to archive message: {e.Message}");
+        }
+    }
+
+    async Task BackfillAllChannelsAsync()
+    {
+        if (_backfillStarted) return;
+        _backfillStarted = true;
+
+        _log.Info("Starting full channel backfill...");
+
+        foreach (var guild in _discord.Guilds)
+        {
+            foreach (var channel in guild.TextChannels)
+            {
+                try
+                {
+                    await BackfillChannelAsync(channel);
+                }
+                catch (Exception e)
+                {
+                    _log.Error($"Backfill failed for #{channel.Name} ({channel.Id}): {e.Message}");
+                }
+            }
+        }
+
+        _backfillComplete = true;
+        _log.Info("Full backfill complete. All channels archived.");
+    }
+
+    async Task BackfillChannelAsync(SocketTextChannel channel)
+    {
+        var totalSaved = 0;
+        var oldestTimestamp = DateTime.MaxValue;
+
+        _log.Info($"Backfilling #{channel.Name}...");
+
+        while (true)
+        {
+            IReadOnlyCollection<IMessage> messages;
+            if (oldestTimestamp == DateTime.MaxValue)
+            {
+                messages = await channel.GetMessagesAsync(100).FlattenAsync();
+            }
+            else
+            {
+                messages = await channel.GetMessagesAsync(oldestTimestamp, Direction.Before, 100).FlattenAsync();
+            }
+
+            if (!messages.Any()) break;
+
+            using var ctx = CreateContext();
+            var newRecords = new List<MessageRecord>();
+
+            foreach (var msg in messages)
+            {
+                if (msg is not IUserMessage userMsg) continue;
+                if (userMsg.Author.IsBot) continue;
+                if (string.IsNullOrEmpty(userMsg.Content)) continue;
+
+                var exists = await ctx.Messages.AnyAsync(m => m.MessageId == msg.Id);
+                if (exists) continue;
+
+                newRecords.Add(new MessageRecord
+                {
+                    MessageId = msg.Id,
+                    ChannelId = channel.Id,
+                    GuildId = channel.Guild.Id,
+                    AuthorId = msg.Author.Id,
+                    AuthorName = msg.Author.Username,
+                    Content = userMsg.Content,
+                    Timestamp = msg.Timestamp.UtcDateTime,
+                    Attachments = msg.Attachments.Count > 0
+                        ? string.Join(";", msg.Attachments.Select(a => a.Url))
+                        : null
+                });
+
+                oldestTimestamp = msg.Timestamp.UtcDateTime;
+            }
+
+            if (newRecords.Count > 0)
+            {
+                await _dbLock.WaitAsync();
+                try
+                {
+                    ctx.Messages.AddRange(newRecords);
+                    await ctx.SaveChangesAsync();
+                }
+                finally
+                {
+                    _dbLock.Release();
+                }
+                totalSaved += newRecords.Count;
+            }
+
+            if (messages.Count < 100) break;
+
+            await Task.Delay(200);
+        }
+
+        _log.Info($"Backfill for #{channel.Name} complete. Saved {totalSaved} messages.");
+    }
+
+    ArchiveDbContext CreateContext()
+    {
+        var connection = new SqliteConnection($"Data Source={DB_PATH}");
+        connection.Open();
+        return new ArchiveDbContext(
+            new DbContextOptionsBuilder<ArchiveDbContext>()
+                .UseSqlite(connection)
+                .Options
+        );
+    }
+}

--- a/src/Services/MessageArchiveService.cs
+++ b/src/Services/MessageArchiveService.cs
@@ -44,11 +44,14 @@ public class MessageArchiveService
     public void Start()
     {
         _discord.MessageReceived += OnMessageReceived;
-
         if (!_backfillComplete)
-        {
-            _ = BackfillAllChannelsAsync();
-        }
+            _discord.Ready += OnReady;
+    }
+
+    async Task OnReady()
+    {
+        _discord.Ready -= OnReady;
+        await BackfillAllChannelsAsync();
     }
 
     async Task OnMessageReceived(SocketMessage socketMessage)
@@ -59,11 +62,6 @@ public class MessageArchiveService
 
         try
         {
-            using var ctx = CreateContext();
-
-            if (await ctx.Messages.AnyAsync(m => m.MessageId == userMessage.Id))
-                return;
-
             var record = new MessageRecord
             {
                 MessageId = userMessage.Id,
@@ -81,6 +79,9 @@ public class MessageArchiveService
             await _dbLock.WaitAsync();
             try
             {
+                using var ctx = CreateContext();
+                if (await ctx.Messages.AnyAsync(m => m.MessageId == userMessage.Id))
+                    return;
                 ctx.Messages.Add(record);
                 await ctx.SaveChangesAsync();
             }
@@ -124,25 +125,24 @@ public class MessageArchiveService
     async Task BackfillChannelAsync(SocketTextChannel channel)
     {
         var totalSaved = 0;
-        var oldestTimestamp = DateTime.MaxValue;
+        ulong? oldestMessageId = null;
 
         _log.Info($"Backfilling #{channel.Name}...");
 
         while (true)
         {
             IReadOnlyCollection<IMessage> messages;
-            if (oldestTimestamp == DateTime.MaxValue)
+            if (oldestMessageId == null)
             {
                 messages = await channel.GetMessagesAsync(100).FlattenAsync();
             }
             else
             {
-                messages = await channel.GetMessagesAsync(oldestTimestamp, Direction.Before, 100).FlattenAsync();
+                messages = await channel.GetMessagesAsync(oldestMessageId.Value, Direction.Before, 100).FlattenAsync();
             }
 
             if (!messages.Any()) break;
 
-            using var ctx = CreateContext();
             var newRecords = new List<MessageRecord>();
 
             foreach (var msg in messages)
@@ -150,9 +150,6 @@ public class MessageArchiveService
                 if (msg is not IUserMessage userMsg) continue;
                 if (userMsg.Author.IsBot) continue;
                 if (string.IsNullOrEmpty(userMsg.Content)) continue;
-
-                var exists = await ctx.Messages.AnyAsync(m => m.MessageId == msg.Id);
-                if (exists) continue;
 
                 newRecords.Add(new MessageRecord
                 {
@@ -167,8 +164,6 @@ public class MessageArchiveService
                         ? string.Join(";", msg.Attachments.Select(a => a.Url))
                         : null
                 });
-
-                oldestTimestamp = msg.Timestamp.UtcDateTime;
             }
 
             if (newRecords.Count > 0)
@@ -176,8 +171,21 @@ public class MessageArchiveService
                 await _dbLock.WaitAsync();
                 try
                 {
+                    using var ctx = CreateContext();
                     ctx.Messages.AddRange(newRecords);
                     await ctx.SaveChangesAsync();
+                }
+                catch (DbUpdateException) when (newRecords.Count > 0)
+                {
+                    using var ctx = CreateContext();
+                    foreach (var record in newRecords)
+                    {
+                        if (!await ctx.Messages.AnyAsync(m => m.MessageId == record.MessageId))
+                        {
+                            ctx.Messages.Add(record);
+                            await ctx.SaveChangesAsync();
+                        }
+                    }
                 }
                 finally
                 {
@@ -185,6 +193,8 @@ public class MessageArchiveService
                 }
                 totalSaved += newRecords.Count;
             }
+
+            oldestMessageId = messages.Last().Id;
 
             if (messages.Count < 100) break;
 

--- a/utsuki-bot.csproj
+++ b/utsuki-bot.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.18.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />


### PR DESCRIPTION
## Summary
- Automatic message archiving to SQLite for all text channels
- Full backfill of historical messages on first boot (respecting Discord rate limits)
- Real-time capture of new messages
- Zero config — auto-starts on bot boot

## Technical Details
- **Storage:** SQLite via EF Core (Microsoft.EntityFrameworkCore.Sqlite)
- **DB location:** `../JsonData/Archive/messages.db` (inside existing Docker volume)
- **Backfill:** Paginated via `GetMessagesAsync` with snowflake cursors, 200ms delay, runs on background thread after `Ready` event
- **Real-time:** `MessageReceived` handler saves every user message
- **Safety:** `SemaphoreSlim` guards all writes, `volatile` flags, duplicate detection by `MessageId`, error isolation per channel
- **Rate limits:** Conservative 200ms between pages + Discord.Net's built-in 429 handling

## Files
| File | Purpose |
|---|---|
| `src/Models/MessageRecord.cs` | EF Core entity |
| `src/Models/ArchiveDbContext.cs` | SQLite DbContext with indexes |
| `src/Services/MessageArchiveService.cs` | Backfill + real-time capture |
| `src/Program.cs` | +1 line to wire `Start()` |

## Test Plan
- [ ] Deploy and verify `messages.db` is created in `JsonData/Archive/`
- [ ] Check logs for "Full backfill complete" message
- [ ] Verify new messages are saved (check `SELECT COUNT(*) FROM Messages`)