### PR TITLE
feat: add message archive system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ FodyWeavers.xsd
 # End of https://www.toptal.com/developers/gitignore/api/csharp
 .idea
 Properties/launchSettings.json
+ArchiveData

--- a/ArchiveData
+++ b/ArchiveData
@@ -1,1 +1,0 @@
-/data/hd-externo/actions-runner/_work/utsuki-bot/utsuki-bot/ArchiveData

--- a/ArchiveData
+++ b/ArchiveData
@@ -1,0 +1,1 @@
+/data/hd-externo/actions-runner/_work/utsuki-bot/utsuki-bot/ArchiveData

--- a/src/Modules/ArchiveModule.cs
+++ b/src/Modules/ArchiveModule.cs
@@ -74,6 +74,29 @@ public class ArchiveModule : InteractionModuleBase<SocketInteractionContext>
         await FollowupAsync(embed: embed.Build());
     }
 
+    [SlashCommand("archiveclean", "Purge messages that don't meet current archive filters")]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    public async Task CleanArchive()
+    {
+        await DeferAsync(ephemeral: true);
+
+        var before = await _archive.GetArchiveStatsAsync();
+        var deleted = await _archive.PurgeBadEntriesAsync();
+        var after = await _archive.GetArchiveStatsAsync();
+
+        var embed = new EmbedBuilder
+        {
+            Title = "Archive Cleanup",
+            Color = deleted > 0 ? Color.Green : Color.Blue
+        };
+
+        embed.AddField("Deleted", $"{deleted:N0} messages", true);
+        embed.AddField("Before", $"{before.TotalMessages:N0} messages", true);
+        embed.AddField("After", $"{after.TotalMessages:N0} messages", true);
+
+        await FollowupAsync(embed: embed.Build(), ephemeral: true);
+    }
+
     static string FormatFileSize(long bytes) => bytes switch
     {
         < 1024 => $"{bytes} B",

--- a/src/Services/MessageArchiveService.cs
+++ b/src/Services/MessageArchiveService.cs
@@ -85,7 +85,7 @@ public class MessageArchiveService
     {
         if (socketMessage is not SocketUserMessage userMessage) return;
         if (userMessage.Author.IsBot) return;
-        if (string.IsNullOrEmpty(userMessage.Content)) return;
+        if (!ShouldArchiveContent(userMessage.Content)) return;
 
         try
         {
@@ -180,7 +180,7 @@ public class MessageArchiveService
             {
                 if (msg is not IUserMessage userMsg) continue;
                 if (userMsg.Author.IsBot) continue;
-                if (string.IsNullOrEmpty(userMsg.Content)) continue;
+                if (!ShouldArchiveContent(userMsg.Content)) continue;
 
                 newRecords.Add(new MessageRecord
                 {
@@ -297,5 +297,13 @@ public class MessageArchiveService
             LastMessage = last.Timestamp,
             ChannelCount = channels
         };
+    }
+
+    static bool ShouldArchiveContent(string content)
+    {
+        if (string.IsNullOrEmpty(content)) return false;
+        if (content.Length <= 2) return false;
+        if (!char.IsLetter(content[0])) return false;
+        return true;
     }
 }

--- a/src/Services/MessageArchiveService.cs
+++ b/src/Services/MessageArchiveService.cs
@@ -299,6 +299,29 @@ public class MessageArchiveService
         };
     }
 
+    public async Task<int> PurgeBadEntriesAsync()
+    {
+        await _dbLock.WaitAsync();
+        try
+        {
+            using var ctx = CreateContext();
+            var bad = await ctx.Messages
+                .Where(m => m.Content.Length <= 2 || !char.IsLetter(m.Content[0]))
+                .ToListAsync();
+            var count = bad.Count;
+            if (count > 0)
+            {
+                ctx.Messages.RemoveRange(bad);
+                await ctx.SaveChangesAsync();
+            }
+            return count;
+        }
+        finally
+        {
+            _dbLock.Release();
+        }
+    }
+
     static bool ShouldArchiveContent(string content)
     {
         if (string.IsNullOrEmpty(content)) return false;


### PR DESCRIPTION
## Summary
- Automatic message archiving to SQLite
- Full historical backfill on first boot, real-time capture thereafter
- Skips bots, short messages (≤2 chars), and non-letter-starting content

## Commands
- `/archivestatus` — Global archive stats (total msgs, channels, users, size)
- `/archivestats [user]` — Per-user message stats
- `/archiveclean` — Purge archived messages that don't match current filters (admin only)

## Volumes
- `./ArchiveData:/app/ArchiveData` — SQLite database for persistence